### PR TITLE
Add ability to use custom fields in posts

### DIFF
--- a/lib/flutter_wordpress.dart
+++ b/lib/flutter_wordpress.dart
@@ -246,6 +246,9 @@ class WordPress {
   /// 
   /// [fetchAll] will make as many API requests as is needed to get all posts.
   /// This may take a while.
+  /// 
+  /// Specify any custom fields in [customFieldNames]. They will be loaded into
+  /// [Post.customFields]
   ///
   /// In case of an error, a [WordPressError] object is thrown.
   async.Future<List<Post>> fetchPosts({
@@ -259,7 +262,8 @@ class WordPress {
     bool fetchFeaturedMedia = false,
     bool fetchAttachments = false,
     String postType = "posts",
-    bool fetchAll = false
+    bool fetchAll = false,
+    Set<String> customFieldNames = null
   }) async {
     if (fetchAll) {
       postParams = postParams.copyWith(perPage: 100);
@@ -276,9 +280,16 @@ class WordPress {
       List<Post> posts = new List();
       final list = json.decode(response.body);
 
-      for (final post in list) {
+      for (final Map<String, dynamic> post in list) {
+        Map<String, dynamic> customFields;
+
+        if (customFieldNames?.isNotEmpty ?? false) {
+          customFields = Map.fromEntries(
+              customFieldNames.map((key) => MapEntry(key, post[key])));
+        }
+
         posts.add(await _postBuilder(
-          post: Post.fromJson(post),
+          post: Post.fromJson(post)..customFields = customFields,
           setAuthor: fetchAuthor,
           setComments: fetchComments,
           orderComments: orderComments,

--- a/lib/flutter_wordpress.dart
+++ b/lib/flutter_wordpress.dart
@@ -315,6 +315,8 @@ class WordPress {
               fetchTags: fetchTags,
               fetchFeaturedMedia: fetchFeaturedMedia,
               fetchAttachments: fetchAttachments,
+              customFieldNames: customFieldNames,
+              postType: postType
             ));
           }
         }

--- a/lib/schemas/post.dart
+++ b/lib/schemas/post.dart
@@ -100,6 +100,9 @@ class Post {
   /// The featured Media of the post.
   Media featuredMedia;
 
+  /// Custom fields on a post.
+  Map<String, dynamic> customFields;
+
   Post({
     this.date,
     this.dateGmt,
@@ -119,6 +122,7 @@ class Post {
     this.format = PostFormat.standard,
     this.categoryIDs,
     this.tagIDs,
+    this.customFields,
   })  : this.title = new Title(rendered: title),
         this.featuredMedia = new Media(sourceUrl: featuredMedia),
         this.content = new Content(rendered: content),
@@ -208,6 +212,12 @@ class Post {
     if (this.categoryIDs != null)
       data['categories'] = listToUrlString(this.categoryIDs);
     if (this.tagIDs != null) data['tags'] = listToUrlString(this.tagIDs);
+    if (customFields != null) {
+      for (final key in customFields.keys) {
+        data[key] = customFields[key]; 
+      }
+    } 
+
     return data;
   }
 


### PR DESCRIPTION
My use case: I wanted to load a field (menu_order) from the post.
I'm not a wordpress expert - is that a common field? Should I instead add a regular property to Post?
I've used the code in this PR and it works well.