### PR TITLE
improve multi-site support

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,5 +1,5 @@
-const URL_JWT_BASE = '/wp-json/jwt-auth/v1';
-const URL_WP_BASE = '/wp-json/wp/v2';
+const URL_JWT_BASE = '?rest_route=/jwt-auth/v1';
+const URL_WP_BASE = '?rest_route=/wp/v2';
 
 const URL_JWT_TOKEN = '$URL_JWT_BASE/token';
 const URL_JWT_TOKEN_VALIDATE = '$URL_JWT_BASE/token/validate';


### PR DESCRIPTION
Accessing a multi-site wordpress setup fails without not using rest_route.

Signed-off-by: Christian Gmeiner <christian.gmeiner@gmail.com>